### PR TITLE
New Parameter "MailboxId"

### DIFF
--- a/Get-MailboxPermissionReport.ps1
+++ b/Get-MailboxPermissionReport.ps1
@@ -32,7 +32,10 @@
   1.0 | Initial community release
   1.1 | Minor PowerShell fix
   1.2 | Minor PowerShell changes
+  1.3 | MailboxId parameter
 	
+  .PARAMETER MailboxId
+  Mailbox filter 
   .PARAMETER CsvFileName
   CSV file name 
 
@@ -44,7 +47,9 @@
 #>
 [CmdletBinding()]
 Param(
+  [string]$MailboxId = '*',
   [string]$CsvFileName = 'MailboxPermissions.csv'
+  
 )
 
 $ScriptDir = Split-Path -Path $script:MyInvocation.MyCommand.Path
@@ -55,7 +60,8 @@ $OutputFile = Join-Path -Path $ScriptDir -ChildPath $CsvFileName
 Write-Verbose $OutputFile
 
 # Fetch mailboxes of type UserMailbox only
-$Mailboxes = Get-Mailbox -RecipientTypeDetails 'UserMailbox' -ResultSize Unlimited | Sort-Object
+$Mailboxes = Get-Mailbox -RecipientTypeDetails 'UserMailbox' -Identity $MailboxId -ResultSize Unlimited | Sort-Object
+
 
 $result = @()
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ The script is intended to run from within an active Exchange 2013 Management She
 
 ## Parameters
 
-### CsvFileName
+### MailboxId (optional, defaulting to "*")
+### CsvFileName (optional, defaulting to "MailboxPermissions.csv")
 
 ## Examples
 
 ``` PowerShell
-.\Get-MailboxPermissionsReport-ps1 -CsvFileName export.csv
+.\Get-MailboxPermissionsReport-ps1 -MailboxId "John*" -CsvFileName export.csv
 ```
 
-Export mailbox permissions to export.csv
+Export permissions of all mailboxes starting with "John*" to file export.csv
 
 ## Note
 


### PR DESCRIPTION
Implemented parameter "MailboxId" to limit the mailboxes to work on.
If omitted, it defaults to all mailboxes as original version.