### PR TITLE
Update Get-MailboxPermissionReport.ps1

### DIFF
--- a/Get-MailboxPermissionReport.ps1
+++ b/Get-MailboxPermissionReport.ps1
@@ -83,7 +83,7 @@ ForEach ($Mailbox in $Mailboxes) {
   Write-Progress -Status $status -Activity $activity -PercentComplete (($count/$MailboxCount)*100) 
     
   # Fetch folders
-  $Folders = Get-MailboxFolderStatistics $Alias | ForEach-Object {$_.folderpath} | ForEach-Object{$_.replace('/','\')}
+  $Folders = Get-MailboxFolderStatistics $Alias | ForEach-Object {$_.folderpath} | ForEach-Object{$_.replace('/Top of Information Store','\')} | ForEach-Object{$_.replace('/','\')}
 
   ForEach ($Folder in $Folders) {
   


### PR DESCRIPTION
Get-MailboxFolderStatistics gibt den Ordner '/Top of Information Store' aus. Nach Umwandlung (replace) erhält Get-MailboxFolderPermission dann 'Mailbox:\Top of Information Store' als Eingabe. Das Format müsste aber Mailbox:\ sein.

Mit vorgeschlagener Änderung klappt das Auslesen des Top of Information Store.